### PR TITLE
Fix multi-threaded environment variable mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,20 @@
  [![Maven Central](https://maven-badges.herokuapp.com/maven-central/uk.org.webcompere/system-stubs-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/uk.org.webcompere/system-stubs-parent/)
 
 > **⚠ WARNING: JDK Compatibility.**
-> From JDK16 onwards, there are deeper restrictons on the ability to use reflection. Previous versions of this library, and others in the space, encounter
+> From JDK16 onwards, there are deeper restrictions on the ability to use reflection. Previous versions of this library, and others in the space, encounter
 > an Illegal Reflective Access warning, or even a runtime error such as `java.lang.reflect.InaccessibleObjectException` when trying to manipulate
 > the `Map` behind the system's environment variables.
 >
-> Consequently, this library now uses `mockito-inline` version 3.x to enable
-> the interception of calls for reading environment variables. This requires consumers
-> to both use a compatible version of Mockito AND be prepared for the _inline_
-> implementation of Mockito mocks.
+> Consequently, this library now uses `bytebuddy` to enable
+> the interception of calls for reading environment variables. This might interact with your
+> chosen version of Mockito or other libraries.
 >
-> Note: Groovy users may need Mockito >= 4.5.0 for compatibility.
+> **⚠ WARNING: JDK Support.**
+> > _This project has now moved to a JDK11 minimum version_
 >
-> Where this isn't appropriate, the [v1.x](https://github.com/webcompere/system-stubs/tree/1.x)
+> Where these aren't appropriate, the [v1.x](https://github.com/webcompere/system-stubs/tree/1.x)
 > version of this will still work for Java versions below 16, and may also be
 > co-erced into working with via the java [command line](https://github.com/stefanbirkner/system-lambda/issues/23#issuecomment-1007608124).
->
-> The long-term plan for this library is to use more interceptors of system
-> functions with Mockito where possible, unless a more direct route becomes available.
-> While this library will continue to be built for Java 8 at the moment, in future it
-> may also move to a higher base version. The v1.x branch will stay on Java 8.
 
 ## Overview
 System Stubs is used to test code which depends on methods in `java.lang.System`.
@@ -45,22 +40,6 @@ It is divided into:
 System Stubs into JUnit 5 tests.
 
 ## Installation
-
-### Dependencies
-
-This library now depends heavily on `mockito-inline`. This is to
-avoid the Illegal Reflective Access from previous attempts to override
-`System.getenv`. To use this library, you need a version of `mockito-inline`
-of `3.12.4` or later.
-
-```xml
-<dependency>
-  <groupId>org.mockito</groupId>
-  <artifactId>mockito-inline</artifactId>
-  <version>3.12.4</version>
-  <scope>test</scope>
-</dependency>
-```
 
 ### Core
 
@@ -809,8 +788,8 @@ simply have a question.
 
 ## Development Guide
 
-System Stubs is built with [Maven](http://maven.apache.org/). **It requires JDK8
-to build** as it depends on some deprecated system class functions.
+System Stubs is built with [Maven](http://maven.apache.org/). **It requires JDK11
+to build**.
 
 If you want to contribute code then:
 
@@ -830,7 +809,7 @@ System Stubs is built with Appveyor: [![Build status](https://ci.appveyor.com/ap
 * With `gpg` installed
 * May need to login to `gpg` to set the passphrase
 * With env variables
-  - `JAVA_HOME` set to JDK8
+  - `JAVA_HOME` set to JDK11
   - `GPG_TTY=$(tty)`
   - `GPG_AGENT_INFO`
 * With the nexus credentials set in the `.m2/settings.xml`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,23 @@
 version: '{build}'
-image:
-  - Visual Studio 2015
-  - Ubuntu
-stack: jdk 8
+
+stack: jdk 11
+environment:
+  matrix:
+    - job_name: Windows build JDK 11
+      appveyor_build_worker_image: Visual Studio 2015
+      JAVA_HOME: C:\Program Files\Java\jdk11
+#    - job_name: Windows build JDK 17
+#      appveyor_build_worker_image: Visual Studio 2019
+#      JAVA_HOME: C:\Program Files\Java\jdk17
+    - job_name: Linux build
+      appveyor_build_worker_image: Ubuntu
+
 cache:
   - /home/appveyor/.m2
   - C:\Users\appveyor\.m2
 build_script:
   - ./mvnw clean package -DskipTests
 test_script:
-  - ./mvnw clean verify
+  - ./mvnw verify
 after_test:
   - sh: CODECOV_TOKEN="be37aef1-3b14-4433-9d91-c8dd3af65285" bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   </scm>
 
   <modules>
+    <module>system-stubs-interceptor</module>
     <module>system-stubs-core</module>
     <module>system-stubs-junit4</module>
     <module>system-stubs-jupiter</module>
@@ -57,10 +58,15 @@
     <dependencies>
       <dependency>
         <groupId>uk.org.webcompere</groupId>
+        <artifactId>system-stubs-interceptor</artifactId>
+        <version>2.0.4-SNAPSHOT</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>uk.org.webcompere</groupId>
         <artifactId>system-stubs-core</artifactId>
         <version>2.0.4-SNAPSHOT</version>
       </dependency>
-
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
@@ -74,6 +80,16 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.14.7</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>1.14.7</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>5.6.2</version>
@@ -82,13 +98,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>3.12.4</version>
+        <version>4.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>3.12.4</version>
+        <artifactId>mockito-core</artifactId>
+        <version>5.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
@@ -117,8 +133,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.maven-compiler-plugin}</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
         <plugin>
@@ -133,7 +149,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.1.4</version>
+          <version>4.7.3.0</version>
           <configuration>
             <effort>Max</effort>
             <threshold>Low</threshold>
@@ -176,7 +192,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.6</version>
+          <version>0.8.8</version>
           <executions>
             <execution>
               <goals>
@@ -191,6 +207,12 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
         </plugin>
 
         <plugin>

--- a/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/environment/EnvironmentVariableMocker.java
+++ b/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/environment/EnvironmentVariableMocker.java
@@ -1,155 +1,67 @@
 package uk.org.webcompere.systemstubs.environment;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.dynamic.loading.ClassReloadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import uk.org.webcompere.systemstubs.internal.ProcessEnvironmentInterceptor;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
 import java.util.*;
-import java.util.stream.Stream;
+import java.util.jar.JarFile;
 
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
 /**
- * This takes control of the environment variables using {@link Mockito#mockStatic}. While there
- * are maps of mock environment variables, the getenv functions will be directed at them. Otherwise,
- * the original ProcessEnvironment method will be called.
+ * This takes control of the environment variables using ByteBuddy. It captures the environment
+ * when first used, and defaults to that. When the {@link EnvironmentVariables} mock wishes to provide
+ * mocking, the alternative map of variables is put into a stack and set as the current variables used by
+ * the interceptor.
  */
 @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED",
     justification = "We need to set up the stub, but interaction is set on construction")
 public class EnvironmentVariableMocker {
     private static final Stack<Map<String, String>> REPLACEMENT_ENV = new Stack<>();
-
-    private static final Set<String> MOCKED_METHODS = Stream.of("getenv", "environment", "toEnvironmentBlock")
-        .collect(toSet());
+    private static final Map<String, String> ORIGINAL_ENV;
 
     static {
+        ORIGINAL_ENV = System.getenv();
         try {
-            Class<?> typeToMock = Class.forName("java.lang.ProcessEnvironment");
-            Mockito.mockStatic(typeToMock, invocationOnMock -> {
-                if (REPLACEMENT_ENV.empty() || !MOCKED_METHODS.contains(invocationOnMock.getMethod().getName())) {
-                    return invocationOnMock.callRealMethod();
-                }
+            Instrumentation instrumentation = ByteBuddyAgent.install();
+            installInterceptorIntoBootLoader(instrumentation);
 
-                if ("toEnvironmentBlock".equals(invocationOnMock.getMethod().getName())) {
-                    return simulateToEnvironmentBlock(invocationOnMock);
-                }
+            var byteBuddy = new ByteBuddy();
+            byteBuddy.redefine(Class.forName("java.lang.ProcessEnvironment"))
+                .method(isStatic().and(namedOneOf("getenv", "environment", "toEnvironmentBlock")))
+                .intercept(MethodDelegation.to(ProcessEnvironmentInterceptor.class))
+                .make()
+                .load(
+                    EnvironmentVariableMocker.class.getClassLoader(),
+                    ClassReloadingStrategy.fromInstalledAgent());
 
-                Map<String, String> currentMockedEnvironment = getenv();
-                if (invocationOnMock.getMethod().getParameterCount() == 0) {
-                    return filterNulls(currentMockedEnvironment);
-                }
-                return currentMockedEnvironment.get(invocationOnMock.getArgument(0, String.class));
-            });
+            ProcessEnvironmentInterceptor.setEnv(ORIGINAL_ENV);
         } catch (Throwable e) {
+
             throw new IllegalStateException("Cannot set up environment mocking: " + e.getMessage() +
-                ". This may be a result of not having the right mockito-inline installed, " +
-                "or may be down to a Java internals change.", e);
+                ".", e);
         }
     }
 
-    /**
-     * The equivalent of <code>getenv</code> in the original ProcessEnvironment, assuming that
-     * mocking is "turned on"
-     * @return the current effective environment
-     */
-    private static Map<String, String> getenv() {
-        return REPLACEMENT_ENV.peek();
-    }
-
-    /**
-     * On Windows, this returns <code>String</code> and converts the inbound Map. On Linux/Mac
-     * this takes a second parameter and returns <code>byte[]</code>. Implementations ripped
-     * from the JDK source implementation
-     * @param invocationOnMock the call to the mocked <code>ProcessEnvironment</code>
-     * @return the environment serialized for the platform
-     */
-    private static Object simulateToEnvironmentBlock(InvocationOnMock invocationOnMock) {
-        if (invocationOnMock.getArguments().length == 1) {
-            return toEnvironmentBlockWindows(invocationOnMock.getArgument(0));
-        } else {
-            return toEnvironmentBlockNix(invocationOnMock.getArgument(0),
-                invocationOnMock.getArgument(1, int[].class));
-        }
-    }
-
-    /**
-     * Ripped from the JDK implementation
-     * @param m the map to convert
-     * @return string representation
-     */
-    private static String toEnvironmentBlockWindows(Map<String, String> m) {
-        // Sort Unicode-case-insensitively by name
-        List<Map.Entry<String,String>> list = m != null ?
-            new ArrayList<>(m.entrySet()) :
-            new ArrayList<>(getenv().entrySet());
-        Collections.sort(list, (e1, e2) -> NameComparator.compareNames(e1.getKey(), e2.getKey()));
-
-        StringBuilder sb = new StringBuilder(list.size() * 30);
-        int cmp = -1;
-
-        // Some versions of MSVCRT.DLL require SystemRoot to be set.
-        // So, we make sure that it is always set, even if not provided
-        // by the caller.
-        final String systemRoot = "SystemRoot";
-
-        for (Map.Entry<String,String> e : list) {
-            String key = e.getKey();
-            String value = e.getValue();
-            if (cmp < 0 && (cmp = NameComparator.compareNames(key, systemRoot)) > 0) {
-                // Not set, so add it here
-                addToEnvIfSet(sb, systemRoot);
-            }
-            addToEnv(sb, key, value);
-        }
-        if (cmp < 0) {
-            // Got to end of list and still not found
-            addToEnvIfSet(sb, systemRoot);
-        }
-        if (sb.length() == 0) {
-            // Environment was empty and SystemRoot not set in parent
-            sb.append('\u0000');
-        }
-        // Block is double NUL terminated
-        sb.append('\u0000');
-        return sb.toString();
-    }
-
-    // code taken from the original in ProcessEnvironment
-    @SuppressFBWarnings({"PZLA_PREFER_ZERO_LENGTH_ARRAYS", "DM_DEFAULT_ENCODING"})
-    private static byte[] toEnvironmentBlockNix(Map<String, String> m, int[] envc) {
-        if (m == null) {
-            return null;
-        }
-        int count = m.size() * 2; // For added '=' and NUL
-        for (Map.Entry<String, String> entry : m.entrySet()) {
-            count += entry.getKey().getBytes().length;
-            count += entry.getValue().getBytes().length;
+    private static void installInterceptorIntoBootLoader(Instrumentation instrumentation) throws IOException {
+        File tempFile = File.createTempFile("interceptor",".jar");
+        tempFile.deleteOnExit();
+        try (FileOutputStream file = new FileOutputStream(tempFile);
+            var resourceStream = EnvironmentVariableMocker.class.getClassLoader()
+                .getResourceAsStream("system-stubs-interceptor.jar")) {
+            resourceStream.transferTo(file);
         }
 
-        byte[] block = new byte[count];
-
-        int i = 0;
-        for (Map.Entry<String, String> entry : m.entrySet()) {
-            final byte[] key   = entry.getKey().getBytes();
-            final byte[] value = entry.getValue().getBytes();
-            System.arraycopy(key, 0, block, i, key.length);
-            i += key.length;
-            block[i++] = (byte) '=';
-            System.arraycopy(value, 0, block, i, value.length);
-            i += value.length + 1;
-            // No need to write NUL byte explicitly
-            //block[i++] = (byte) '\u0000';
-        }
-        envc[0] = m.size();
-        return block;
-    }
-
-    private static Map<String, String> filterNulls(Map<String, String> currentMockedEnvironment) {
-        return currentMockedEnvironment.entrySet()
-            .stream()
-            .filter(entry -> entry.getValue() != null)
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        instrumentation.appendToBootstrapClassLoaderSearch(new JarFile(tempFile));
     }
 
     /**
@@ -165,6 +77,7 @@ public class EnvironmentVariableMocker {
             .filter(entry -> !newEnvironmentVariables.containsKey(entry.getKey()))
             .forEach(entry -> newEnvironmentVariables.put(entry.getKey(), entry.getValue()));
         REPLACEMENT_ENV.push(newEnvironmentVariables);
+        ProcessEnvironmentInterceptor.setEnv(newEnvironmentVariables);
     }
 
     /**
@@ -172,10 +85,17 @@ public class EnvironmentVariableMocker {
      * the original implementation of the getenv functions will be called directly again.
      * @return true if mocking has now stopped
      */
-    public static boolean pop() {
+    public static synchronized boolean pop() {
         if (!REPLACEMENT_ENV.empty()) {
             REPLACEMENT_ENV.pop();
         }
+
+        if (!REPLACEMENT_ENV.empty()) {
+            ProcessEnvironmentInterceptor.setEnv(REPLACEMENT_ENV.peek());
+        } else {
+            ProcessEnvironmentInterceptor.setEnv(ORIGINAL_ENV);
+        }
+
         return REPLACEMENT_ENV.empty();
     }
 
@@ -184,51 +104,15 @@ public class EnvironmentVariableMocker {
      * @param theOneToPop the map to remove
      * @return true if removed
      */
-    public static boolean remove(Map<String, String> theOneToPop) {
-        return REPLACEMENT_ENV.remove(theOneToPop);
-    }
+    public static synchronized boolean remove(Map<String, String> theOneToPop) {
+        var result = REPLACEMENT_ENV.remove(theOneToPop);
 
-    @SuppressFBWarnings("SE_COMPARATOR_SHOULD_BE_SERIALIZABLE")
-    private static final class NameComparator
-        implements Comparator<String> {
-
-        public int compare(String s1, String s2) {
-            return compareNames(s1, s2);
+        if (!REPLACEMENT_ENV.empty()) {
+            ProcessEnvironmentInterceptor.setEnv(REPLACEMENT_ENV.peek());
+        } else {
+            ProcessEnvironmentInterceptor.setEnv(ORIGINAL_ENV);
         }
 
-        public static int compareNames(String s1, String s2) {
-            // We can't use String.compareToIgnoreCase since it
-            // canonicalizes to lower case, while Windows
-            // canonicalizes to upper case!  For example, "_" should
-            // sort *after* "Z", not before.
-            int n1 = s1.length();
-            int n2 = s2.length();
-            int min = Math.min(n1, n2);
-            for (int i = 0; i < min; i++) {
-                char c1 = s1.charAt(i);
-                char c2 = s2.charAt(i);
-                if (c1 != c2) {
-                    c1 = Character.toUpperCase(c1);
-                    c2 = Character.toUpperCase(c2);
-                    if (c1 != c2) {
-                        // No overflow because of numeric promotion
-                        return c1 - c2;
-                    }
-                }
-            }
-            return n1 - n2;
-        }
-    }
-
-    // add the environment variable to the child, if it exists in parent
-    private static void addToEnvIfSet(StringBuilder sb, String name) {
-        String s = getenv().get(name);
-        if (s != null) {
-            addToEnv(sb, name, s);
-        }
-    }
-
-    private static void addToEnv(StringBuilder sb, String name, String val) {
-        sb.append(name).append('=').append(val).append('\u0000');
+        return result;
     }
 }

--- a/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/security/NoExitSecurityManager.java
+++ b/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/security/NoExitSecurityManager.java
@@ -61,11 +61,6 @@ public class NoExitSecurityManager extends SecurityManager {
     }
 
     @Override
-    public boolean getInCheck() {
-        return originalSecurityManager != null && originalSecurityManager.getInCheck();
-    }
-
-    @Override
     public Object getSecurityContext() {
         return (originalSecurityManager == null) ? super.getSecurityContext()
             : originalSecurityManager.getSecurityContext();
@@ -219,29 +214,9 @@ public class NoExitSecurityManager extends SecurityManager {
     }
 
     @Override
-    public boolean checkTopLevelWindow(Object window) {
-        return (originalSecurityManager == null) ? super.checkTopLevelWindow(window)
-            : originalSecurityManager.checkTopLevelWindow(window);
-    }
-
-    @Override
     public void checkPrintJobAccess() {
         if (originalSecurityManager != null) {
             originalSecurityManager.checkPrintJobAccess();
-        }
-    }
-
-    @Override
-    public void checkSystemClipboardAccess() {
-        if (originalSecurityManager != null) {
-            originalSecurityManager.checkSystemClipboardAccess();
-        }
-    }
-
-    @Override
-    public void checkAwtEventQueueAccess() {
-        if (originalSecurityManager != null) {
-            originalSecurityManager.checkAwtEventQueueAccess();
         }
     }
 
@@ -263,13 +238,6 @@ public class NoExitSecurityManager extends SecurityManager {
     public void checkSetFactory() {
         if (originalSecurityManager != null) {
             originalSecurityManager.checkSetFactory();
-        }
-    }
-
-    @Override
-    public void checkMemberAccess(Class<?> clazz, int which) {
-        if (originalSecurityManager != null) {
-            originalSecurityManager.checkMemberAccess(clazz, which);
         }
     }
 

--- a/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/stream/input/ThrowAtEndStream.java
+++ b/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/stream/input/ThrowAtEndStream.java
@@ -1,5 +1,7 @@
 package uk.org.webcompere.systemstubs.stream.input;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -20,6 +22,7 @@ public class ThrowAtEndStream extends DecoratingAltStream {
      * @param decoratee real source of the bytes
      * @param ioException the {@link IOException} to throw when running out of data
      */
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public ThrowAtEndStream(AltInputStream decoratee, IOException ioException) {
         super(decoratee);
         this.ioException = Objects.requireNonNull(ioException);
@@ -30,6 +33,7 @@ public class ThrowAtEndStream extends DecoratingAltStream {
      * @param decoratee real source of the bytes
      * @param runtimeException the {@link RuntimeException} to throw when running out of data
      */
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public ThrowAtEndStream(AltInputStream decoratee, RuntimeException runtimeException) {
         super(decoratee);
         this.runtimeException = Objects.requireNonNull(runtimeException);

--- a/system-stubs-core/src/test/java/uk/org/webcompere/systemstubs/CatchSystemExitTest.java
+++ b/system-stubs-core/src/test/java/uk/org/webcompere/systemstubs/CatchSystemExitTest.java
@@ -244,24 +244,6 @@ class CatchSystemExitTest {
 			= new SecurityManagerMock();
 
 		@Test
-		void getInCheck_is_delegated_to_original_security_manager(
-		) throws Exception {
-			originalSecurityManager.inCheck = true;
-			AtomicBoolean inCheck = new AtomicBoolean();
-			SystemStubs.withSecurityManager(
-				originalSecurityManager,
-				() -> SystemStubs.catchSystemExit(
-					() -> {
-						inCheck.set(getSecurityManager().getInCheck());
-						//ensure that catchSystemExit does not fail
-						exit(ARBITRARY_STATUS);
-					}
-				)
-			);
-			assertThat(inCheck).isTrue();
-		}
-
-		@Test
 		void security_context_of_original_security_manager_is_provided(
 		) throws Exception {
 			Object context = new Object();
@@ -280,29 +262,6 @@ class CatchSystemExitTest {
 				)
 			);
 			assertThat(contextDuringExecution).hasValue(context);
-		}
-
-		@Test
-		void checkTopLevelWindow_is_delegated_to_original_security_manager(
-		) throws Exception {
-			originalSecurityManager.topLevelWindow = true;
-			Object window = new Object();
-			AtomicBoolean check = new AtomicBoolean();
-			SystemStubs.withSecurityManager(
-				originalSecurityManager,
-				() -> SystemStubs.catchSystemExit(
-					() -> {
-						check.set(
-							getSecurityManager().checkTopLevelWindow(window)
-						);
-						//ensure that catchSystemExit does not fail
-						exit(ARBITRARY_STATUS);
-					}
-				)
-			);
-			assertThat(check).isTrue();
-			assertThat(originalSecurityManager.windowOfCheckTopLevelWindowCall)
-				.isSameAs(window);
 		}
 
 		@Test

--- a/system-stubs-core/src/test/java/uk/org/webcompere/systemstubs/SecurityManagerMock.java
+++ b/system-stubs-core/src/test/java/uk/org/webcompere/systemstubs/SecurityManagerMock.java
@@ -156,18 +156,6 @@ class SecurityManagerMock extends SecurityManager {
 	}
 
 	@Override
-	public void checkSystemClipboardAccess() {
-		logMethodCall("checkSystemClipboardAccess");
-		super.checkSystemClipboardAccess();
-	}
-
-	@Override
-	public void checkAwtEventQueueAccess() {
-		logMethodCall("checkAwtEventQueueAccess");
-		super.checkAwtEventQueueAccess();
-	}
-
-	@Override
 	public void checkPackageAccess(String s) {
 		logMethodCall("checkPackageAccess", String.class, s);
 		super.checkPackageAccess(s);
@@ -201,15 +189,6 @@ class SecurityManagerMock extends SecurityManager {
 	}
 
 	@Override
-	public void checkMemberAccess(Class<?> aClass, int i) {
-		logMethodCall(
-			"checkMemberAccess",
-			new Class[] { Class.class, int.class },
-			aClass, i);
-		super.checkMemberAccess(aClass, i);
-	}
-
-	@Override
 	public void checkSecurityAccess(String s) {
 		logMethodCall("checkSecurityAccess", String.class, s);
 		super.checkSecurityAccess(s);
@@ -222,22 +201,9 @@ class SecurityManagerMock extends SecurityManager {
 	}
 
 	@Override
-	public boolean getInCheck() {
-		logMethodCall("getInCheck");
-		return inCheck;
-	}
-
-	@Override
 	public ThreadGroup getThreadGroup() {
 		logMethodCall("getThreadGroup");
 		return threadGroup;
-	}
-
-	@Override
-	public boolean checkTopLevelWindow(Object window) {
-		logMethodCall("checkTopLevelWindow", Object.class, window);
-		windowOfCheckTopLevelWindowCall = window;
-		return topLevelWindow;
 	}
 
 	void logMethodCall(String name) {

--- a/system-stubs-interceptor/pom.xml
+++ b/system-stubs-interceptor/pom.xml
@@ -9,12 +9,12 @@
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>system-stubs-core</artifactId>
+  <artifactId>system-stubs-interceptor</artifactId>
   <version>2.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>System Stubs Core</name>
-  <description>A collection of functions for testing code which uses java.lang.System.</description>
+  <name>System Stubs Interceptor</name>
+  <description>The jar used for byte buddy stubbing</description>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
@@ -23,53 +23,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>uk.org.webcompere</groupId>
-      <artifactId>system-stubs-interceptor</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy-agent</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
   </dependencies>
 
   <build>
-      <resources>
-        <resource>
-          <directory>../system-stubs-interceptor/target/</directory>
-          <includes>
-            <include>system-stubs-interceptor.jar</include>
-          </includes>
-        </resource>
-      </resources>
+    <finalName>system-stubs-interceptor</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/system-stubs-interceptor/src/main/java/uk/org/webcompere/systemstubs/internal/ProcessEnvironmentInterceptor.java
+++ b/system-stubs-interceptor/src/main/java/uk/org/webcompere/systemstubs/internal/ProcessEnvironmentInterceptor.java
@@ -1,0 +1,162 @@
+package uk.org.webcompere.systemstubs.internal;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toMap;
+
+public class ProcessEnvironmentInterceptor {
+    private static Map<String, String> CURRENT_ENVIRONMENT_VARIABLES = new HashMap<>();
+
+    @SuppressFBWarnings("EI_EXPOSE_STATIC_REP2")
+    public static void setEnv(Map<String, String> env) {
+        CURRENT_ENVIRONMENT_VARIABLES = env;
+    }
+
+    /**
+     * The equivalent of <code>getenv</code> in the original ProcessEnvironment, assuming that
+     * mocking is "turned on"
+     * @return the current effective environment
+     */
+    public static Map<String, String> getenv() {
+        return filterNulls(CURRENT_ENVIRONMENT_VARIABLES);
+    }
+
+    public static String getenv(String name) {
+        return getenv().get(name);
+    }
+
+    public static Map<String, String> environment() {
+        return getenv();
+    }
+
+    /**
+     * Ripped from the JDK implementation
+     * @param m the map to convert
+     * @return string representation
+     */
+    public static String toEnvironmentBlock(Map<String, String> m) {
+        // Sort Unicode-case-insensitively by name
+        List<Map.Entry<String,String>> list = m != null ?
+            new ArrayList<>(m.entrySet()) :
+            new ArrayList<>(getenv().entrySet());
+        Collections.sort(list, (e1, e2) -> NameComparator.compareNames(e1.getKey(), e2.getKey()));
+
+        StringBuilder sb = new StringBuilder(list.size() * 30);
+        int cmp = -1;
+
+        // Some versions of MSVCRT.DLL require SystemRoot to be set.
+        // So, we make sure that it is always set, even if not provided
+        // by the caller.
+        final String systemRoot = "SystemRoot";
+
+        for (Map.Entry<String,String> e : list) {
+            String key = e.getKey();
+            String value = e.getValue();
+            if (cmp < 0 && (cmp = NameComparator.compareNames(key, systemRoot)) > 0) {
+                // Not set, so add it here
+                addToEnvIfSet(sb, systemRoot);
+            }
+            addToEnv(sb, key, value);
+        }
+        if (cmp < 0) {
+            // Got to end of list and still not found
+            addToEnvIfSet(sb, systemRoot);
+        }
+        if (sb.length() == 0) {
+            // Environment was empty and SystemRoot not set in parent
+            sb.append('\u0000');
+        }
+        // Block is double NUL terminated
+        sb.append('\u0000');
+        return sb.toString();
+    }
+
+    /**
+     * Convert the requested environment variables to a Nix format
+     * @param m the map of variables
+     * @param envc the target array to receive the size
+     * @return the byte array of environment variables
+     */
+    // code taken from the original in ProcessEnvironment
+    @SuppressFBWarnings({"PZLA_PREFER_ZERO_LENGTH_ARRAYS", "DM_DEFAULT_ENCODING"})
+    public static byte[] toEnvironmentBlock(Map<String, String> m, int[] envc) {
+        if (m == null) {
+            return null;
+        }
+        int count = m.size() * 2; // For added '=' and NUL
+        for (Map.Entry<String, String> entry : m.entrySet()) {
+            count += entry.getKey().getBytes().length;
+            count += entry.getValue().getBytes().length;
+        }
+
+        byte[] block = new byte[count];
+
+        int i = 0;
+        for (Map.Entry<String, String> entry : m.entrySet()) {
+            final byte[] key   = entry.getKey().getBytes();
+            final byte[] value = entry.getValue().getBytes();
+            System.arraycopy(key, 0, block, i, key.length);
+            i += key.length;
+            block[i++] = (byte) '=';
+            System.arraycopy(value, 0, block, i, value.length);
+            i += value.length + 1;
+            // No need to write NUL byte explicitly
+            //block[i++] = (byte) '\u0000';
+        }
+        envc[0] = m.size();
+        return block;
+    }
+
+    private static Map<String, String> filterNulls(Map<String, String> currentMockedEnvironment) {
+        return currentMockedEnvironment.entrySet()
+            .stream()
+            .filter(entry -> entry.getValue() != null)
+            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @SuppressFBWarnings("SE_COMPARATOR_SHOULD_BE_SERIALIZABLE")
+    private static final class NameComparator
+        implements Comparator<String> {
+
+        public int compare(String s1, String s2) {
+            return compareNames(s1, s2);
+        }
+
+        public static int compareNames(String s1, String s2) {
+            // We can't use String.compareToIgnoreCase since it
+            // canonicalizes to lower case, while Windows
+            // canonicalizes to upper case!  For example, "_" should
+            // sort *after* "Z", not before.
+            int n1 = s1.length();
+            int n2 = s2.length();
+            int min = Math.min(n1, n2);
+            for (int i = 0; i < min; i++) {
+                char c1 = s1.charAt(i);
+                char c2 = s2.charAt(i);
+                if (c1 != c2) {
+                    c1 = Character.toUpperCase(c1);
+                    c2 = Character.toUpperCase(c2);
+                    if (c1 != c2) {
+                        // No overflow because of numeric promotion
+                        return c1 - c2;
+                    }
+                }
+            }
+            return n1 - n2;
+        }
+    }
+
+    // add the environment variable to the child, if it exists in parent
+    private static void addToEnvIfSet(StringBuilder sb, String name) {
+        String s = getenv().get(name);
+        if (s != null) {
+            addToEnv(sb, name, s);
+        }
+    }
+
+    private static void addToEnv(StringBuilder sb, String name, String val) {
+        sb.append(name).append('=').append(val).append('\u0000');
+    }
+}

--- a/system-stubs-junit4/pom.xml
+++ b/system-stubs-junit4/pom.xml
@@ -17,8 +17,8 @@
   <description>JUnit4 rules using System Stubs implementation</description>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -37,13 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.12.4</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/system-stubs-jupiter/pom.xml
+++ b/system-stubs-jupiter/pom.xml
@@ -17,8 +17,8 @@
   <description>JUnit Jupiter Extension for System Stubs</description>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -38,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
     <!-- used for test examples -->

--- a/system-stubs-jupiter/src/test/java/uk/org/webcompere/systemstubs/jupiter/examples/EnvironmentVariablesAcrossThreads.java
+++ b/system-stubs-jupiter/src/test/java/uk/org/webcompere/systemstubs/jupiter/examples/EnvironmentVariablesAcrossThreads.java
@@ -1,0 +1,42 @@
+package uk.org.webcompere.systemstubs.jupiter.examples;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static java.lang.System.getenv;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SystemStubsExtension.class)
+class EnvironmentVariablesAcrossThreads {
+
+    @SystemStub
+    private EnvironmentVariables environmentVariables = new EnvironmentVariables("foo", "bar");
+
+    @Test
+    void theVariablesAreSetInTheTestMainThread() {
+        assertThat(getenv("foo")).isEqualTo("bar");
+    }
+
+    @Test
+    void theVariablesAreVisibleToWorkerThreads() throws Exception {
+        Map<String, String> result = new HashMap<>();
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        new Thread(() -> {
+            result.put("foo", getenv("foo"));
+            latch.countDown();
+        }).start();
+
+        latch.await();
+
+        assertThat(result).containsEntry("foo", "bar");
+    }
+}


### PR DESCRIPTION
Owing to a limitation of Mockito's `mockStatic` function, which deliberately limits static mocking to the calling thread, the environment variable mocking has not worked in any other worker threads involved in the test.

This was reported in #45 

By switching from using Mockito to using `ByteBuddy` and mocking the `ProcessEnvironment` closer to the bytecode, we can overcome this constraint.