### PR TITLE
Provide backwards compatibility for tools that should be able to mock the environment

### DIFF
--- a/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/environment/EnvironmentVariableMocker.java
+++ b/system-stubs-core/src/main/java/uk/org/webcompere/systemstubs/environment/EnvironmentVariableMocker.java
@@ -30,7 +30,7 @@ public class EnvironmentVariableMocker {
     private static final Map<String, String> ORIGINAL_ENV;
 
     static {
-        ORIGINAL_ENV = System.getenv();
+        ORIGINAL_ENV = new HashMap<>(System.getenv());
         try {
             Instrumentation instrumentation = ByteBuddyAgent.install();
             installInterceptorIntoBootLoader(instrumentation);

--- a/system-stubs-core/src/test/java/uk/org/webcompere/systemstubs/PropertiesFileLoadingTest.java
+++ b/system-stubs-core/src/test/java/uk/org/webcompere/systemstubs/PropertiesFileLoadingTest.java
@@ -16,6 +16,7 @@ public class PropertiesFileLoadingTest {
             new EnvironmentVariables()
                 .set(fromResource("test.properties"))
                 .execute(() -> {
+                   assertThat(System.getenv()).containsEntry("value1", "foo").containsEntry("value2", "bar");
                    assertThat(System.getenv("value1")).isEqualTo("foo");
                    assertThat(System.getenv("value2")).isEqualTo("bar");
                 });

--- a/system-stubs-jupiter/pom.xml
+++ b/system-stubs-jupiter/pom.xml
@@ -46,6 +46,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>2.1.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>2.7.15</version>

--- a/system-stubs-jupiter/src/test/java/uk/org/webcompere/systemstubs/jupiter/compatibility/DoesNotPreventJUnitPioneerFromWorkingTest.java
+++ b/system-stubs-jupiter/src/test/java/uk/org/webcompere/systemstubs/jupiter/compatibility/DoesNotPreventJUnitPioneerFromWorkingTest.java
@@ -1,0 +1,41 @@
+package uk.org.webcompere.systemstubs.jupiter.compatibility;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledForJreRange(max = JRE.JAVA_16)
+class DoesNotPreventJUnitPioneerFromWorkingTest {
+
+    @Nested
+    @ExtendWith(SystemStubsExtension.class)
+    static class StubsWorks {
+        @SystemStub
+        private EnvironmentVariables variables;
+
+        @Test
+        void canStubVariable() {
+            variables.set("MACHINE", "hot");
+
+            assertThat(System.getenv("MACHINE")).isEqualTo("hot");
+        }
+    }
+
+    @Nested
+    @SetEnvironmentVariable(key="MACHINE", value="COLD")
+    static class PioneerWorks {
+        @Test
+        void canPioneerVariable() {
+            assertThat(System.getenv("MACHINE")).isEqualTo("cold");
+        }
+    }
+
+}


### PR DESCRIPTION
Make the `System.getenv` and the `ProcessEnvironment.theEnvironment` appear to be present for tools that like to use it.

Fixes #67 