### PR TITLE
Upgrade version of bytebuddy to support Java 22 and 23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.9</version>
+        <version>1.15.0</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.9</version>
+        <version>1.15.0</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
Fix version of bytebuddy to support Java 22 and 23.

Bytebuddy support 23 since 1.14.16