### PR TITLE
Upgrade byte buddy from  1.17.4 to 1.17.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <version.nexus-staging-maven-plugin>1.7.0 </version.nexus-staging-maven-plugin>
     <version.maven-release-plugin>3.1.1</version.maven-release-plugin>
     <version.maven-compiler-plugin>3.13.0</version.maven-compiler-plugin>
-    <version.byte.buddy>1.17.4</version.byte.buddy>
+    <version.byte.buddy>1.17.7</version.byte.buddy>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The main motivation is extend the support for Java 25 and avoid the need for experimental flags

From `[1.17.5](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.5)`

> Update ASM to version 9.8 to support Java 25 using ASM reader and writer.

The other bumps should not hurt as it'll upgrade us to the latest version

Changes: 

https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.5
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.6
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.7